### PR TITLE
Add CI image build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,5 +41,6 @@ jobs:
         context: .
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker Image Build
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+    - name: Cache
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: cache-mount
+        key: cache-mount-${{ hashFiles('Dockerfile') }}
+    - name: Restore Docker cache mounts
+      uses: reproducible-containers/buildkit-cache-dance@v3
+      with:
+        builder: ${{ steps.setup-buildx.outputs.name }}
+        cache-dir: cache-mount
+        dockerfile: Dockerfile
+        skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         path: cache-mount
         key: cache-mount-${{ hashFiles('Dockerfile') }}
+    - uses: actions/checkout@v4
     - name: Restore Docker cache mounts
       uses: reproducible-containers/buildkit-cache-dance@v3
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,33 @@
-FROM ubuntu:25.04
+FROM perl:5-bookworm
 
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
-COPY cpanfile /
-
-ENV EV_EXTRA_DEFS=-DEV_NO_ATFORK
 ENV DEBIAN_FRONTEND=noninteractive 
 
-RUN  apt-get update && apt-get install make g++ curl wget checkinstall -y 
+RUN --mount=target=/var/lib/apt/lists,type=cache --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install --no-install-recommends -y postgresql-common r-base r-recommended pandoc && \
+  /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && apt-get install --no-install-recommends -y postgresql postgresql-17-pgvector
 
-# Added 'pandoc' to the list of installed packages
-RUN apt-get update && \
-  apt-get install perl cpanminus pandoc libio-socket-ssl-perl postgresql postgresql-server-dev-17 postgresql-17-pgvector libpq-dev libdbd-pg-perl r-base r-recommended -y && \
-  cpanm -v -f --installdeps . -M https://cpan.metacpan.org && \
-  rm -rf /root/.cpanm/* /usr/local/share/man/*
+COPY cpanfile /usr/src/app
 
-RUN mkdir /app
-COPY Application /app
-COPY sql_template.sql /app
-COPY entrypoint.sh /app
-RUN ln -s /usr/bin/R /usr/local/bin/R
-RUN R -e "install.packages(c('rjson'), dependencies=TRUE, repos='http://cran.rstudio.com/')"
+RUN --mount=type=cache,target=/root/.cpanm cpanm -v -f --installdeps --notest . -M https://cpan.metacpan.org
 
-RUN echo "local all  all  trust" > /etc/postgresql/17/main/pg_hba.conf && \
+RUN ln -s /usr/bin/R /usr/local/bin/R && \
+    R -e "install.packages(c('rjson'), dependencies=TRUE, repos='http://cran.rstudio.com/')" && \
+    echo "local all  all  trust" > /etc/postgresql/17/main/pg_hba.conf && \
     echo "host  all  all  127.0.0.1/32 trust" >> /etc/postgresql/17/main/pg_hba.conf && \
-    echo "host  all  all  ::1/128    trust" >> /etc/postgresql/17/main/pg_hba.conf
-RUN echo "listen_addresses='*'" >> /etc/postgresql/17/main/postgresql.conf
+    echo "host  all  all  ::1/128    trust" >> /etc/postgresql/17/main/pg_hba.conf && \
+    echo "listen_addresses='*'" >> /etc/postgresql/17/main/postgresql.conf
 
+COPY sql_template.sql .
 RUN /etc/init.d/postgresql start && \
     until pg_isready -U postgres; do echo "Waiting for PostgreSQL..."; sleep 1; done && \
     psql -U postgres --command "CREATE USER docker WITH SUPERUSER PASSWORD 'docker';" 2>&1 | tee /tmp/psql_create_user.log && \
     createdb -U docker llm_patchbay 2>&1 | tee /tmp/psql_createdb.log && \
-    psql -U docker llm_patchbay < /app/sql_template.sql 2>&1 | tee /tmp/psql_import.log
+    psql -U docker llm_patchbay < sql_template.sql 2>&1 | tee /tmp/psql_import.log
+
+COPY entrypoint.sh .
+COPY Application .
 
 VOLUME /var/lib/postgresql/17/main
 
@@ -38,7 +35,6 @@ VOLUME /var/lib/postgresql/17/main
 # COPY install_ollama.sh /app
 # RUN /app/install_ollama.sh
 
-WORKDIR /app
 EXPOSE 3036
 
-ENTRYPOINT ["/app/entrypoint.sh"]
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/cpanfile
+++ b/cpanfile
@@ -16,3 +16,5 @@ requires "Statistics::R";
 requires "JQ::Lite";
 requires "XML::XML2JSON";
 requires "Archive::Zip";
+requires "IO::Socket::SSL";
+requires "DBD::Pg";

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Start the PostgreSQL service
 /etc/init.d/postgresql start
@@ -13,4 +13,4 @@ fi
 
 # Start the main application in the foreground
 echo "Starting LLMPatchbay backend..."
-hypnotoad -f /app/backend.pl
+hypnotoad -f /usr/src/app/backend.pl


### PR DESCRIPTION
Add GitHub Actions workflow for prebuilt images hosted on GHCR. Also includes some optimization to the image build process including

- Improved layering and caching strategy
- Migration to image for easier perl versioning
- Migration to psql installation from upstream psql apt repository for easier psql and pgvector upgrades
- Using bash for the entrypoint for better signal handling

This also reduces the build time from ~30m to ~4m (without caching) on the test system and the image size from ~2.4GB to ~1.6GB.